### PR TITLE
Add `<!DOCTYPE html>` to put the page in Standards Mode

### DIFF
--- a/src/index.template.html
+++ b/src/index.template.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 
 <head>


### PR DESCRIPTION
If it isn't included, browsers will use quirks mode, which emulates the behaviours of some older browsers instead of following the standards.