### PR TITLE
Make host and port configurable

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,10 +159,10 @@ pub fn run_wasm() {
     let index_processed = index_template.replace("{{name}}", &args.name);
     std::fs::write(example_dest.join("index.html"), index_processed).unwrap();
 
-    let host = args.host.unwrap_or("localhost".into());
+    let host = args.host.unwrap_or_else(|| "localhost".into());
     let port = args
         .port
-        .unwrap_or("8000".into())
+        .unwrap_or_else(|| "8000".into())
         .parse()
         .expect("Port should be an integer");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ impl Args {
                 name: unused_args.remove(0),
                 features,
                 host,
-                port
+                port,
             }),
             len => Err(format!(
                 "Expected exactly one free arg, but there was {} free args: {:?}",
@@ -160,7 +160,11 @@ pub fn run_wasm() {
     std::fs::write(example_dest.join("index.html"), index_processed).unwrap();
 
     let host = args.host.unwrap_or("localhost".into());
-    let port = args.port.unwrap_or("8000".into()).parse().expect("Port should be an integer");
+    let port = args
+        .port
+        .unwrap_or("8000".into())
+        .parse()
+        .expect("Port should be an integer");
 
     // run webserver on destination folder
     println!("\nServing `{}` on http://{}:{}", args.name, host, port);


### PR DESCRIPTION
I wanted to test the results by serving them to another machine in my local network, but I realize this tool is hard-coded to listen at localhost, so I made these changes to make it configurable, keeping the old defaults.

This adds two new `--host` and `--port` command line flags, which are by default still "localhost" and "8000" respectively.