### PR TITLE
Remove <h1> and provide css configuration

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,7 @@ cargo-run-wasm = "0.1.0"
 
 ```rust
 fn main() {
-    cargo_run_wasm::run_wasm();
+    cargo_run_wasm::run_wasm_with_css("");
 }
 ```
 
@@ -73,6 +73,16 @@ cargo-run-wasm is not available as a [cargo custom command](https://doc.rust-lan
 * issues with mismatches between wasm-bindgen versions
 * issues with keeping a stable interface with the wasm app
 * gives the idea that the command is compatible with every project that uses wasm which is not the case.
+
+## Configuration
+
+If you wish to set custom css, do so in the string argument to `run_wasm_with_css`.
+
+However it is not possible to set custom html from cargo-run-wasm, instead any DOM elements you require should be created from within your crate or example using [web-sys](https://docs.rs/web-sys/latest/web_sys/struct.Document.html#method.create_element) or another crate.
+The reasoning is that in the case an example requires custom HTML it will probably:
+
+* require HTML that is unique to that example while cargo-run-wasm is only capable of global settings
+* require web-sys or similar to interact with the DOM at runtime anyway
 
 ## MSRV
 

--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,7 @@ cargo-run-wasm = "0.1.0"
 
 ```rust
 fn main() {
-    cargo_run_wasm::run_wasm_with_css("");
+    cargo_run_wasm::run_wasm_with_css("body { margin: 0px; }");
 }
 ```
 

--- a/src/index.template.html
+++ b/src/index.template.html
@@ -6,10 +6,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>{{name}}</title>
   <style type="text/css">
-    body {
-      margin: 0px;
-    }
-
     {{css}}
   </style>
 </head>

--- a/src/index.template.html
+++ b/src/index.template.html
@@ -4,6 +4,14 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>{{name}}</title>
+  <style type="text/css">
+    body {
+      margin: 0px;
+    }
+
+    {{css}}
+  </style>
 </head>
 
 <body>
@@ -14,7 +22,6 @@
     });
   </script>
 
-  <h1>{{name}}</h1>
 </body>
 
 </html>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,8 +83,17 @@ impl Args {
 /// 5. Launch a tiny webserver to serve index.html + your wasm
 ///
 /// It will block forever to keep the webserver running until killed with ctrl-c or similar
+///
+/// The css argument will be included directly into a `<style></style>` element in the generated page.
+/// By default the body element will include some margin, so for full page apps you will want to remove that by calling like:
+/// ```no_run
+///     cargo_run_wasm::run_wasm_with_css("body { margin: 0px; }");
+/// ```
 pub fn run_wasm_with_css(css: &str) {
     // validate css
+    //
+    // Someone could easily get around this with some extra spaces
+    // but im not about to import regex or do a complicated implementation by hand.
     if css.contains("</style>") {
         panic!(
             "`</style>` detected in the css. This is disallowed to prevent injecting elements into the DOM."


### PR DESCRIPTION
Closes https://github.com/rukai/cargo-run-wasm/issues/3

I've decided to have `margin: 0px` as part of the example documentation rather than included in the template by default.
I see a few benefits to this approach:
* less magic, all of the css comes from a single location under the users control, making it a lot easier to for example compare functional differences between a custom page and a page served from cargo-run-wasm
* in the unusual case that someone actually wants the default margin functionality
* when copy/pasted from the example it is obvious from a glance that the css arg is supposed to contain css because it already does contain css

I dont see any other css settings that are worthy of including in the example documentation.