### PR TITLE
Rewrite arg handling to pass through to `cargo build`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,13 +7,19 @@
 Allows running wasm applications and examples as simply as:
 
 ```bash
-cargo run-wasm crate_name
+cargo run-wasm --example example_name
 ```
 
 or
 
 ```bash
-cargo run-wasm --example example_name
+cargo run-wasm --package crate_name
+```
+
+or
+
+```bash
+cargo run-wasm --bin bin_name
 ```
 
 In the background it:


### PR DESCRIPTION
Previously we manually passed through a few important commands and used a free arg as a name given to `--package`.
This turned out to not be flexible enough as demonstrated by https://github.com/rukai/cargo-run-wasm/issues/13 where access to `--bin` in some form was needed.

Instead this PR rewrites cargo-run-wasm to pass all args directly through to `cargo build`, with the exception of args like `--package`, `--bin` and `--example` which we use to extract the binary name.
This should both make the implementation simpler and make the API closer to that of `cargo run`.