### PR TITLE
Release cargo-run-wasm 0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cargo-run-wasm"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "devserver_lib",
  "pico-args",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-run-wasm"
 repository = "https://github.com/rukai/cargo-run-wasm"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2018"
 authors = ["Lucas Kent <rubickent@gmail.com>"]
 license = "MIT OR Apache-2.0"

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,9 @@
+## 0.3
+
+* rust API is unchanged
+* CLI API is redone to expose all of the `cargo build` CLI API
+   + The only thing backwards incompatible is that `cargo run-wasm crate_name` is no longer valid. Instead you should use `cargo run-wasm --package crate_name`
+
+## 0.2
+
+* prehistory

--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-cargo-run-wasm = "0.2.0"
+cargo-run-wasm = "0.3.0"
 ```
 
 `main.rs`:


### PR DESCRIPTION
I could possibly get away with releasing as 0.2.1 considering the rust API is unchanged, but having a `cargo update` result in a previously working CLI command no longer work seems breaking enough to warrant a breaking release.
So I decided to release a 0.3.

Also added a changelog to assist in migration.