### PR TITLE
Cleanup and make CargoDirectories::new fast path faster

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,7 +162,6 @@ pub fn run_wasm_with_css(css: &str) {
 
     let profile = if args.release { "release" } else { "debug" };
 
-    // build wasm example via cargo
     let cargo = env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
 
     let CargoDirectories {

--- a/src/target_dir.rs
+++ b/src/target_dir.rs
@@ -42,11 +42,14 @@ impl CargoDirectories {
     pub fn new(cargo_executable: &str) -> CargoDirectories {
         let mut manifest_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
 
-        // First try to find the target directory ourselves
-        // Its possible for this to return false positives if the user leaves a directory named target in the wrong spot.
+        // First try to find the directories ourselves.
+        // We can rely on Cargo.toml being correct as Cargo issues warnings when unused/incorrect Cargo.toml's are left around.
+        // It is however possible for this to return false positives if the user leaves an unused directory named target next to their Cargo.toml
+        // I think this is acceptable though.
         loop {
             let target = manifest_dir.join("target");
-            if target.exists() {
+            let cargo_toml = manifest_dir.join("Cargo.toml");
+            if target.exists() && cargo_toml.exists() {
                 return CargoDirectories {
                     target_directory: target,
                     workspace_root: manifest_dir,


### PR DESCRIPTION
Simplifies the implementation, makes it more robust (traverses all parent dirs instead of just 1), and makes the fast path faster.

The previous implementation of CargoDirectories::new took 110us to complete on wgpu.
With this change it takes 7us on wgpu.

In comparison the slow path takes 12ms (I'm on a different machine now), so we certainly dont care about initially waiting 7us there.
