### PR TITLE
Make target_dir module private

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-pub mod target_dir;
+mod target_dir;
 
 use pico_args::Arguments;
 use std::env;


### PR DESCRIPTION
Oops, forgot about this and its a breaking change.
Will have to go into 0.4