### PR TITLE
feat: expose `Args` and new `run_wasm_with_css_with_args`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ Normally you can run just `cargo run` to run the main binary of the current pack
 The equivalent of that is `cargo run-wasm --package name_of_current_package`
 ";
 
-struct Args {
+pub struct Args {
     help: bool,
     profile: Option<String>,
     build_only: bool,
@@ -159,6 +159,17 @@ Remove one flag or the other to continue."#
 ///     cargo_run_wasm::run_wasm_with_css("body { margin: 0px; }");
 /// ```
 pub fn run_wasm_with_css(css: &str) {
+    let args = match Args::from_env() {
+        Ok(args) => args,
+        Err(err) => {
+            println!("{}\n\n{}", err, HELP);
+            return;
+        }
+    };
+    run_wasm_with_css_and_args(css, args)
+}
+
+pub fn run_wasm_with_css_and_args(css: &str, args: Args) {
     // validate css
     //
     // Someone could easily get around this with some extra spaces
@@ -169,13 +180,6 @@ pub fn run_wasm_with_css(css: &str) {
         )
     }
 
-    let args = match Args::from_env() {
-        Ok(args) => args,
-        Err(err) => {
-            println!("{}\n\n{}", err, HELP);
-            return;
-        }
-    };
     if args.help {
         println!("{}", HELP);
         return;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,8 +68,10 @@ struct Args {
 
 impl Args {
     pub fn from_env() -> Result<Self, String> {
-        let mut args = Arguments::from_env();
+        Self::from_args(Arguments::from_env())
+    }
 
+    pub fn from_args(mut args: Arguments) -> Result<Self, String> {
         let release_arg = args.contains("--release") || args.contains("-r");
         let profile_arg: Option<String> = args.opt_value_from_str("--profile").unwrap();
         if release_arg && profile_arg.is_some() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@ impl Args {
         let release_arg = args.contains("--release") || args.contains("-r");
         let profile_arg: Option<String> = args.opt_value_from_str("--profile").unwrap();
         if release_arg && profile_arg.is_some() {
-            return Err(r#"conflicting usage of --profile and --release.
+            return Err(r#"conflicting usage of `--profile` and `--release`.
 The `--release` flag is the same as `--profile=release`.
 Remove one flag or the other to continue."#
                 .to_owned());


### PR DESCRIPTION
It's currently impossible to embed `cargo-run-wasm` as a library unless one dedicates their entire command line interface to be forwarded to the library. This doesn't compose very well, sadly. We in [`wgpu`](https://github.com/gfx-rs/wgpu) would really like to be able to use this as a subcommand in a new `cargo xtask` flow (see https://github.com/gfx-rs/wgpu/pull/3844 for more details).

More details on the current state of this PR: https://github.com/rukai/cargo-run-wasm/pull/37#issuecomment-1578949032