### PR TITLE
Change run_wasm_cli_with_css to run_wasm_with_css readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -50,7 +50,7 @@ cargo-run-wasm = "0.3.0"
 
 ```rust
 fn main() {
-    cargo_run_wasm::run_wasm_cli_with_css("body { margin: 0px; }");
+    cargo_run_wasm::run_wasm_with_css("body { margin: 0px; }");
 }
 ```
 


### PR DESCRIPTION
It looks like the example is out of date, as the function to run is now called `run_wasm_with_css`